### PR TITLE
chore: migrate package to official npm organization scope and add CD workflow.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish Package to NPM
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Publish Package
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
-  "name": "node-neutralino",
+  "name": "@neutralinojs-contrib/nodeneutralino",
   "package-name": "node-neutralino",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Wrapper project for Neutralinojs backend",
   "entry point": "./src/index.js",
   "main": "./src/index.js",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "author": {
     "name": "Viral-Gupta and Neutralinojs community",
     "email": "neutralinojs@gmail.com",


### PR DESCRIPTION
This PR migrates the package to the newly created official npm organization scope (`@neutralinojs-contrib/node-neutralino`) and updates its `package.json` configuration for public access. It also adds a continuous delivery (CD) GitHub Actions workflow (`publish.yml`) to automatically publish new package versions to npm whenever a new release is published. 